### PR TITLE
ci: fix changelog path

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog
-          path: ${{ github.workspace }}-CHANGELOG.md
+          path: ${{ github.workspace }}-CHANGELOG
       - name: Release
         uses: actions/create-release@v1
         env:
@@ -73,6 +73,6 @@ jobs:
         with:
           tag_name: "v${{ needs.bump_version.outputs.version }}"
           release_name: "Release v${{ needs.bump_version.outputs.version }}"
-          body_path: ${{ github.workspace }}-CHANGELOG.md
+          body_path: ${{ github.workspace }}-CHANGELOG/changelog.md
           draft: false
           prerelease: false


### PR DESCRIPTION
The `download-artifact` action extracts to a directory even if it's a single file.